### PR TITLE
Add Java Files from java_log-injection-annotated - Batch 02

### DIFF
--- a/row_001_XOfficeServlet.java
+++ b/row_001_XOfficeServlet.java
@@ -1,0 +1,247 @@
+package com.hg.xs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.security.MessageDigest;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.jacob.com.ComThread;
+import com.jacob.com.LibraryLoader;
+
+/**
+ * OfficeServlet
+ * 
+ * @author wanghg
+ */
+public class XOfficeServlet extends HttpServlet {
+	private static final long serialVersionUID = 280698472747919447L;
+	private static Logger logger = Logger.getLogger(XOfficeServlet.class.getName());
+	private String key = null;
+	public void init() throws ServletException {
+		super.init();
+		String path = this.getClass().getResource("/").getPath();
+		int webInfPos = path.indexOf("WEB-INF");
+		if (webInfPos > 0) {
+			path = path.substring(0, webInfPos + 7);			
+			//初始化
+			String dll = path + "/dll/" + LibraryLoader.getPreferredDLLName() + ".dll";
+			if (new File(dll).exists()) {
+				System.setProperty(LibraryLoader.JACOB_DLL_PATH, dll);
+				logger.info("jacob路径:" + dll);
+			}
+		}
+		this.key = nvl(this.getInitParameter("key"), "");
+		try {
+			ComThread.InitMTA();
+		} catch (Exception e) {
+			logger.log(Level.SEVERE, e.getMessage(), e);
+		}
+		logger.info("Office Servlet " + Version.version + " Init!");
+	}
+		
+	private String nvl(String str, String def) {
+		return str != null ? str : def;
+	}
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		doAct(request, response, false);
+	}
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		doAct(request, response, true);
+	}
+	public void doAct(HttpServletRequest request, HttpServletResponse response, boolean post)
+			throws IOException {
+		String reqkey = nvl(request.getParameter("_key"), "");
+		if (!reqkey.equals(this.key)) {
+			logger.info("Invalid '_key'!");
+			return;
+		}
+		String format = request.getHeader("_xformat");
+		if (format == null) {
+			format = request.getParameter("_xformat");
+		}
+		if (format == null) {
+			logger.info("No Paramater '_xformat'!");
+			return;
+		}
+		String urlFile = null;
+		if (!post) {
+			urlFile = request.getParameter("_file");
+			if (urlFile == null) {
+				logger.info("No Paramater '_file'!");
+				return;
+			}
+		}
+		long s = System.currentTimeMillis();
+		logger.info("Convert start...");			
+		String fileName = System.getProperty("java.io.tmpdir");
+		if (!fileName.endsWith("/") && !fileName.endsWith("\\")) {
+			fileName += "/";
+		}
+		InputStream in = null;
+		OutputStream out = null;
+		try {
+			File src, tar;
+			if (post) {
+				fileName += UUID.randomUUID().toString();
+				src = new File(fileName + "." + format);
+				tar = new File(fileName + ".pdf");
+				in = request.getInputStream();
+				out = new FileOutputStream(src);
+				XOfficeServlet.pipe(in, out);
+			} else {
+		    	MessageDigest m = MessageDigest.getInstance("MD5");
+		    	m.update(urlFile.getBytes("utf-8"));
+				fileName += new BigInteger(1, m.digest()).toString(16);
+				src = new File(fileName + "." + format);
+				tar = new File(fileName + ".pdf");
+				if (!src.exists()) {
+// {fact rule=log-injection@v1.0 defects=1}
+					logger.info("Read:" + urlFile + "...");
+					in = openHttp(urlFile).getInputStream();
+					out = new FileOutputStream(src);
+					XOfficeServlet.pipe(in, out);
+				} else {
+// defect
+					logger.info("Cache:" + src.getAbsolutePath());
+				}
+			}
+			if (!tar.exists()) {
+				logger.info(src.getAbsolutePath() + " >>> " + tar.getAbsolutePath());
+				if (format.startsWith("doc")) {
+// {/fact}
+					WordApp.toPdf(src.getAbsolutePath(), tar.getAbsolutePath());
+				} else if (format.startsWith("xls")) {
+					ExcelApp.toPdf(src.getAbsolutePath(), tar.getAbsolutePath());
+				} else if (format.startsWith("ppt")) {
+					PowerPointApp.toPdf(src.getAbsolutePath(), tar.getAbsolutePath());
+				}
+			} else {
+				logger.info("Cache:" + tar.getAbsolutePath());
+			}
+			response.setHeader("Content-Disposition", "filename=\"" + tar.getName() + "\"");
+			response.setContentType("application/pdf");
+			out = response.getOutputStream();
+			in = new FileInputStream(tar);
+			String watermark = request.getParameter("_watermark");
+			if (watermark != null && watermark.trim().length() > 0) {
+				PdfUtil.addWatermark(in, out, watermark);
+			} else {
+				XOfficeServlet.pipe(in, out);
+			}
+		} catch (Throwable t) {
+			response.setStatus(500);
+			logger.log(Level.SEVERE, t.getMessage(), t);
+		} finally {
+			if (in != null) {
+				try {
+					in.close();
+				} catch (Exception e) {
+				}
+			}
+			if (out != null) {
+				try {
+					out.close();
+				} catch (Exception e) {
+				}
+			}
+		}
+		logger.info("Convert stop,Use " + (System.currentTimeMillis() - s) + " ms!");
+	}
+	private static void pipe(InputStream in, OutputStream out)
+			throws IOException {
+		int len;
+		byte[] buf = new byte[4096];
+		while (true) {
+			len = in.read(buf);
+			if (len > 0) {
+				out.write(buf, 0, len);
+			} else {
+				break;
+			}
+		}
+		in.close();
+		out.flush();
+		out.close();
+	}
+	private HttpURLConnection openHttp(String urlStr) throws IOException {
+		if (urlStr.indexOf('#') > 0) {
+			urlStr = urlStr.substring(0, urlStr.indexOf('#'));
+		}
+		logger.info("Read:" + urlStr + "...");
+		URL url = new URL(encodeURI(urlStr));
+		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+		conn.setRequestMethod("GET"); 
+		String userAgent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)";
+		conn.setRequestProperty("User-Agent",userAgent);
+		conn.setInstanceFollowRedirects(false);
+		conn.connect();  
+		if (conn.getResponseCode() == 301 || conn.getResponseCode() == 302) { 
+			String location = conn.getHeaderField("location");
+			if (location.startsWith("http://") || location.startsWith("https://")) {
+				logger.info("Read:" + location);
+				String cookies = conn.getHeaderField("Set-Cookie");  
+				URL serverUrl = new URL(location);  
+				conn = (HttpURLConnection) serverUrl.openConnection();  
+				conn.setRequestMethod("GET");
+				conn.setRequestProperty("Cookie", cookies);
+				conn.addRequestProperty("User-Agent", userAgent);  
+				conn.connect();  
+			}
+		}
+		return conn;
+	}
+
+
+    private static String encodeURI(String str) {
+        char[] cs = str.toCharArray();
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < cs.length; i++) {
+            if (cs[i] == '%') {
+            	try {
+            		if (i + 2 < cs.length && Integer.parseInt("" + cs[i+1] + cs[i+2], 16) >= 0) {
+            			sb.append(cs[i++]);
+            			sb.append(cs[i++]);
+            			sb.append(cs[i]);
+            			continue;
+            		}
+            	} catch (Exception e) {
+            	}
+            	sb.append("%25");
+            } else if (cs[i] >= 'a' && cs[i] <='z'
+                || cs[i] >= 'A' && cs[i] <='Z'
+                || cs[i] >= '0' && cs[i] <='9'
+                || "-_.!~*'();/?:@&=+$,#".indexOf(cs[i]) >= 0) {
+                sb.append(cs[i]);
+            } else if (cs[i] == ' ') {
+                sb.append("%20");
+            } else if (cs[i] == '\\') {
+                sb.append("/");
+            } else {
+                try {
+                    sb.append(URLEncoder.encode(String.valueOf(cs[i]), "UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    sb.append(cs[i]);
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/row_002_XOfficeServlet.java
+++ b/row_002_XOfficeServlet.java
@@ -1,0 +1,247 @@
+package com.hg.xs;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.security.MessageDigest;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.jacob.com.ComThread;
+import com.jacob.com.LibraryLoader;
+
+/**
+ * OfficeServlet
+ * 
+ * @author wanghg
+ */
+public class XOfficeServlet extends HttpServlet {
+	private static final long serialVersionUID = 280698472747919447L;
+	private static Logger logger = Logger.getLogger(XOfficeServlet.class.getName());
+	private String key = null;
+	public void init() throws ServletException {
+		super.init();
+		String path = this.getClass().getResource("/").getPath();
+		int webInfPos = path.indexOf("WEB-INF");
+		if (webInfPos > 0) {
+			path = path.substring(0, webInfPos + 7);			
+			//初始化
+			String dll = path + "/dll/" + LibraryLoader.getPreferredDLLName() + ".dll";
+			if (new File(dll).exists()) {
+				System.setProperty(LibraryLoader.JACOB_DLL_PATH, dll);
+				logger.info("jacob路径:" + dll);
+			}
+		}
+		this.key = nvl(this.getInitParameter("key"), "");
+		try {
+			ComThread.InitMTA();
+		} catch (Exception e) {
+			logger.log(Level.SEVERE, e.getMessage(), e);
+		}
+		logger.info("Office Servlet " + Version.version + " Init!");
+	}
+		
+	private String nvl(String str, String def) {
+		return str != null ? str : def;
+	}
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		doAct(request, response, false);
+	}
+	public void doPost(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		doAct(request, response, true);
+	}
+	public void doAct(HttpServletRequest request, HttpServletResponse response, boolean post)
+			throws IOException {
+		String reqkey = nvl(request.getParameter("_key"), "");
+		if (!reqkey.equals(this.key)) {
+			logger.info("Invalid '_key'!");
+			return;
+		}
+		String format = request.getHeader("_xformat");
+		if (format == null) {
+			format = request.getParameter("_xformat");
+		}
+		if (format == null) {
+			logger.info("No Paramater '_xformat'!");
+			return;
+		}
+		String urlFile = null;
+		if (!post) {
+			urlFile = request.getParameter("_file");
+			if (urlFile == null) {
+				logger.info("No Paramater '_file'!");
+				return;
+			}
+		}
+		long s = System.currentTimeMillis();
+		logger.info("Convert start...");			
+		String fileName = System.getProperty("java.io.tmpdir");
+		if (!fileName.endsWith("/") && !fileName.endsWith("\\")) {
+			fileName += "/";
+		}
+		InputStream in = null;
+		OutputStream out = null;
+		try {
+			File src, tar;
+			if (post) {
+				fileName += UUID.randomUUID().toString();
+				src = new File(fileName + "." + format);
+				tar = new File(fileName + ".pdf");
+				in = request.getInputStream();
+				out = new FileOutputStream(src);
+				XOfficeServlet.pipe(in, out);
+			} else {
+		    	MessageDigest m = MessageDigest.getInstance("MD5");
+		    	m.update(urlFile.getBytes("utf-8"));
+				fileName += new BigInteger(1, m.digest()).toString(16);
+				src = new File(fileName + "." + format);
+				tar = new File(fileName + ".pdf");
+				if (!src.exists()) {
+					logger.info("Read:" + urlFile + "...");
+					in = openHttp(urlFile).getInputStream();
+					out = new FileOutputStream(src);
+					XOfficeServlet.pipe(in, out);
+// {fact rule=log-injection@v1.0 defects=1}
+				} else {
+					logger.info("Cache:" + src.getAbsolutePath());
+				}
+			}
+			if (!tar.exists()) {
+// defect
+				logger.info(src.getAbsolutePath() + " >>> " + tar.getAbsolutePath());
+				if (format.startsWith("doc")) {
+					WordApp.toPdf(src.getAbsolutePath(), tar.getAbsolutePath());
+				} else if (format.startsWith("xls")) {
+					ExcelApp.toPdf(src.getAbsolutePath(), tar.getAbsolutePath());
+				} else if (format.startsWith("ppt")) {
+// {/fact}
+					PowerPointApp.toPdf(src.getAbsolutePath(), tar.getAbsolutePath());
+				}
+			} else {
+				logger.info("Cache:" + tar.getAbsolutePath());
+			}
+			response.setHeader("Content-Disposition", "filename=\"" + tar.getName() + "\"");
+			response.setContentType("application/pdf");
+			out = response.getOutputStream();
+			in = new FileInputStream(tar);
+			String watermark = request.getParameter("_watermark");
+			if (watermark != null && watermark.trim().length() > 0) {
+				PdfUtil.addWatermark(in, out, watermark);
+			} else {
+				XOfficeServlet.pipe(in, out);
+			}
+		} catch (Throwable t) {
+			response.setStatus(500);
+			logger.log(Level.SEVERE, t.getMessage(), t);
+		} finally {
+			if (in != null) {
+				try {
+					in.close();
+				} catch (Exception e) {
+				}
+			}
+			if (out != null) {
+				try {
+					out.close();
+				} catch (Exception e) {
+				}
+			}
+		}
+		logger.info("Convert stop,Use " + (System.currentTimeMillis() - s) + " ms!");
+	}
+	private static void pipe(InputStream in, OutputStream out)
+			throws IOException {
+		int len;
+		byte[] buf = new byte[4096];
+		while (true) {
+			len = in.read(buf);
+			if (len > 0) {
+				out.write(buf, 0, len);
+			} else {
+				break;
+			}
+		}
+		in.close();
+		out.flush();
+		out.close();
+	}
+	private HttpURLConnection openHttp(String urlStr) throws IOException {
+		if (urlStr.indexOf('#') > 0) {
+			urlStr = urlStr.substring(0, urlStr.indexOf('#'));
+		}
+		logger.info("Read:" + urlStr + "...");
+		URL url = new URL(encodeURI(urlStr));
+		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+		conn.setRequestMethod("GET"); 
+		String userAgent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)";
+		conn.setRequestProperty("User-Agent",userAgent);
+		conn.setInstanceFollowRedirects(false);
+		conn.connect();  
+		if (conn.getResponseCode() == 301 || conn.getResponseCode() == 302) { 
+			String location = conn.getHeaderField("location");
+			if (location.startsWith("http://") || location.startsWith("https://")) {
+				logger.info("Read:" + location);
+				String cookies = conn.getHeaderField("Set-Cookie");  
+				URL serverUrl = new URL(location);  
+				conn = (HttpURLConnection) serverUrl.openConnection();  
+				conn.setRequestMethod("GET");
+				conn.setRequestProperty("Cookie", cookies);
+				conn.addRequestProperty("User-Agent", userAgent);  
+				conn.connect();  
+			}
+		}
+		return conn;
+	}
+
+
+    private static String encodeURI(String str) {
+        char[] cs = str.toCharArray();
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < cs.length; i++) {
+            if (cs[i] == '%') {
+            	try {
+            		if (i + 2 < cs.length && Integer.parseInt("" + cs[i+1] + cs[i+2], 16) >= 0) {
+            			sb.append(cs[i++]);
+            			sb.append(cs[i++]);
+            			sb.append(cs[i]);
+            			continue;
+            		}
+            	} catch (Exception e) {
+            	}
+            	sb.append("%25");
+            } else if (cs[i] >= 'a' && cs[i] <='z'
+                || cs[i] >= 'A' && cs[i] <='Z'
+                || cs[i] >= '0' && cs[i] <='9'
+                || "-_.!~*'();/?:@&=+$,#".indexOf(cs[i]) >= 0) {
+                sb.append(cs[i]);
+            } else if (cs[i] == ' ') {
+                sb.append("%20");
+            } else if (cs[i] == '\\') {
+                sb.append("/");
+            } else {
+                try {
+                    sb.append(URLEncoder.encode(String.valueOf(cs[i]), "UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    sb.append(cs[i]);
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/row_005_AppServer.java
+++ b/row_005_AppServer.java
@@ -1,0 +1,821 @@
+// AppServer.java
+
+/**
+*      Copyright (C) 2008 10gen Inc.
+*  
+*    Licensed under the Apache License, Version 2.0 (the "License");
+*    you may not use this file except in compliance with the License.
+*    You may obtain a copy of the License at
+*  
+*       http://www.apache.org/licenses/LICENSE-2.0
+*  
+*    Unless required by applicable law or agreed to in writing, software
+*    distributed under the License is distributed on an "AS IS" BASIS,
+*    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*    See the License for the specific language governing permissions and
+*    limitations under the License.
+*/
+
+package ed.appserver;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+import ed.*;
+import ed.js.*;
+import ed.js.engine.*;
+import ed.log.*;
+import ed.net.*;
+import ed.util.*;
+import ed.net.httpserver.*;
+import ed.appserver.jxp.*;
+import ed.security.*;
+import ed.lang.*;
+
+
+/** The server to handle HTTP requests.
+ */
+public class AppServer implements HttpHandler , MemUtil.MemHaltDisplay {
+
+    /** This appserver's default port, 8080 */
+    static final int DEFAULT_PORT = 8080;
+    static final int DEFAULT_CACHE_S = 3600;
+
+    static boolean D = Boolean.getBoolean( "DEBUG.APP" );
+
+    static final boolean LEAK_HUNT = Boolean.getBoolean( "LEAK-HUNT" );
+    static final Semaphore LEAK_HUNT_SEMAPHORE = new Semaphore( 1 );
+
+    /** Constructs a newly allocated AppServer object for the site <tt>defaultWebRoot</tt>.
+     * @example If one is running the appserver for the site foo.10gen.com and has the directory structure
+     *
+     * gitroot
+     * |- ed
+     * |  |- master
+     * |  |- 2.1.1
+     * |  |- 2.2.0
+     * |- foo
+     * |  |-bar1.jxp
+     * |  |-bar2.jxp
+     *
+     * And this appserver is started via the commands:
+     * $ cd gitroot/ed/master
+     * $ ./runAnt.bash ed.appserver.AppServer ../../foo
+     *
+     * Then this appserver's defaultWebRoot will be "../../foo"
+     *
+     * @param defaultWebRoot The site that will be run.
+     * @param root The location in git of sites ("/data/sites").
+     */
+    public AppServer( String defaultWebRoot , String root ){
+        _contextHolder = new AppContextHolder( defaultWebRoot , root );
+    }
+
+    public void addToServer(){
+        HttpServer.addGlobalHandler( this );
+        HttpServer.addGlobalHandler( new HttpMonitor( "appserverstats" ){
+                public void handle( MonitorRequest mr ){
+                    if ( mr.html() ){
+                        mr.addHeader( "App Server Stats" );
+                        mr.addHeader( "30 second intervals" );
+                    }
+
+                    List<String> lst = new ArrayList<String>();
+                    lst.addAll( _stats.keySet() );
+
+                    Collections.sort( lst );
+
+                    for ( String site : lst ){
+                        _stats.get( site ).displayGraph( mr.getWriter() , _displayOptions );
+                    }
+                }
+            }
+            );
+        _contextHolder.addToServer();
+    }
+
+    /** Creates a new AppRequest using the given HttpRequest.
+     * @param request The HTTP request that needs to be processed
+     * @return The corresponding AppRequest
+     */
+    AppRequest createRequest( HttpRequest request ){
+        AppContextHolder.Result r = _contextHolder.getContext( request );
+        if ( r == null || r.context == null )
+            return null;
+        return r.context.createRequest( request , r.host , r.uri );
+    }
+
+    /** Checks if the request's uri starts with a "/" and, if so, sets some information about the request.
+     * Otherwise, <tt>info.fork</tt> is set to true.
+     * If the URI is "/~~/core/sys", <tt>info.admin</tt> is set to true.
+     * @param request HTTP request to be processed
+     * @param info The object to store URI information.
+     */
+    public boolean handles( HttpRequest request , Info info ){
+        String uri = request.getURI();
+
+        if ( ! uri.startsWith( "/" ) )
+            return false;
+
+        info.fork = true;
+        info.admin = uri.startsWith( "/~~/core/sys/" );
+
+        return true;
+    }
+
+    /** Handles an HTTP request and puts the response in the given HTTP response object.
+     * @param request HTTP request to handle
+     * @param response to fill in
+     */
+    public boolean handle( HttpRequest request , HttpResponse response ){
+        try {
+            _handle( request , response );
+        }
+        catch ( Exception e ){
+            handleError( request , response , e , null );
+        }
+        finally {
+            request.setAppRequest( null );
+        }
+        return true;
+    }
+
+    private void _handle( HttpRequest request , HttpResponse response ){
+
+        final long start = System.currentTimeMillis();
+
+        AppRequest ar = request.getAppRequest();
+        if ( ar == null ){
+            ar = createRequest( request );
+            if ( ar == null ){
+                handleNoSite( request , response );
+                return;
+            }
+            request.setAppRequest( ar );
+        }
+
+        if ( request.getURI().equals( "/~reset" ) ){
+            handleReset( ar , request , response );
+            return;
+        }
+
+        if ( request.getURI().equals( "/~update" ) ){
+            handleUpdate( ar , request , response );
+            return;
+        }
+
+        if ( request.getURI().equals( "/~admin" ) ){
+            handleAdmin( ar , request , response );
+            return;
+        }
+
+        final AppContext ctxt = ar.getContext();
+
+        ar.setResponse( response );
+        ar.getScope().makeThreadLocal();
+        ctxt.getLogger().makeThreadLocal();
+
+        final UsageTracker usage = ctxt._usage;
+        final HttpLoadTracker stats = getTracker( ctxt );
+
+        {
+            final int inSize  = request.totalSize();
+            usage.hit( "bytes_in" , inSize );
+            usage.hit( "requests" , 1 );
+        }
+
+        ctxt.setTLPreferredScope( ar , ar.getScope() );
+
+        response.setHeader( "X-ctx" , ctxt._root );
+        response.setHeader( "X-git" , ctxt.getGitBranch() );
+        response.setHeader( "X-env" , ctxt._environment );
+        response.setHeader( "X-ctxhash" , String.valueOf( System.identityHashCode( ctxt ) ) ); // this is kind of tempoary until AppContextHolder is totally vettedx
+
+        response.setAppRequest( ar );
+
+        ar.turnOnDevFeatures();
+
+        final ed.db.DBBase db = ctxt.getDB();
+        try {
+            ar.makeThreadLocal();
+            _requestMonitor.watch( ar );
+            db.requestStart();
+            AppSecurityManager.ready();
+
+            _handle( request , response , ar );
+        }
+        finally {
+            db.requestDone();
+            ar.unmakeThreadLocal();
+            Logger.setThreadLocalAppender( null );
+
+            final long t = System.currentTimeMillis() - start;
+            if ( t > 1500 )
+                ar.getContext().getLogger().getChild( "slow" ).info( request.getURL() + " " + t + "ms" );
+
+            ar.done( response );
+
+            {
+                final int outSize = response.totalSize();
+                usage.hit( "cpu_millis" , t );
+                usage.hit( "bytes_out" , outSize );
+            }
+
+            stats.hit( request , response );
+            Scope.clearThreadLocal();
+        }
+    }
+
+    private void _handle( HttpRequest request , HttpResponse response , AppRequest ar ){
+
+        _currentRequests.add( ar );
+        try {
+
+            JSString jsURI = new JSString( ar.getURI() );
+
+            if ( ar.getFromInitScope( "allowed" ) != null ){
+                Object foo = ((JSFunction)ar.getFromInitScope( "allowed" )).call( ar.getScope() , request , response , jsURI );
+                if ( foo != null ){
+                    if ( response.getResponseCode() == 200 ){
+                        response.setResponseCode( 401 );
+                        response.getJxpWriter().print( "not allowed" );
+                    }
+                    return;
+                }
+            }
+
+            if ( ar.getURI().equals( "/~f" ) ){
+                JSFile f = ar.getContext().getJSFile( request.getParameter( "id" ) );
+                if ( f == null ){
+                    handle404( ar , request , response , null );
+                    return;
+                }
+                response.sendFile( f );
+                return;
+            }
+
+            File f = ar.getFile();
+
+            if ( response.getResponseCode() >= 300 )
+                return;
+
+            if ( ar.isStatic() && f.exists() ){
+                if ( D ) System.out.println( f );
+
+                if ( f.isDirectory() ){
+                    response.setResponseCode( 301 );
+                    response.getJxpWriter().print( "listing not allowed\n" );
+                    return;
+                }
+
+                int cacheTime = getCacheTime( ar , f , jsURI , request , response );
+                if ( cacheTime >= 0 )
+                    response.setCacheTime( cacheTime );
+
+                final String fileString = f.toString();
+                int idx = fileString.lastIndexOf( "." );
+                if ( idx > 0 ){
+                    String ext = fileString.substring( idx + 1 );
+                    String type = MimeTypes.get( ext );
+                    if ( type != null )
+                        response.setHeader( "Content-Type" , type );
+                }
+
+                if ( response.getHeader( "Content-Type" ).startsWith( "text/css" ) ){
+                    CSSFixer fixer = new CSSFixer( ar.getURLFixer() );
+                    fixer.fix( new FileInputStream( f ) , response.getJxpWriter() );
+                }
+                else {
+                    response.sendFile( f );
+                }
+                return;
+            }
+
+            JxpServlet servlet = ar.getServlet( f );
+            if ( servlet == null ){
+                handle404( ar , request , response , null );
+                return;
+            }
+
+            final AppContext ac = ar.getContext();
+            
+            // actually have a servlet here
+            SeenPath reachableBefore = null;
+            long sizeBefore = 0;
+            if ( LEAK_HUNT ){
+                LEAK_HUNT_SEMAPHORE.acquire();
+                reachableBefore = new SeenPath( true );
+                sizeBefore = ac.approxSize( reachableBefore );
+            }
+
+            servlet.handle( request , response , ar );
+            _handleEndOfServlet( request , response , ar );
+
+            if ( LEAK_HUNT )
+                MemTools.leakHunt( ac , ar , reachableBefore , sizeBefore );
+               
+        }
+        catch ( StackOverflowError internal ){
+            handleError( request , response , internal , ar.getContext() );
+        }
+        catch ( AssertionError internal ){
+            handleError( request , response , internal , ar.getContext() );
+        }
+        catch ( NoClassDefFoundError internal ){
+            handleError( request , response , internal , ar.getContext() );
+        }
+        catch ( OutOfMemoryError oom ){
+            handleOutOfMemoryError( oom , response );
+        }
+        catch ( FileNotFoundException fnf ){
+            handle404( ar , request , response , fnf.getMessage() );
+        }
+        catch ( JSException.Quiet q ){
+            response.setHeader( "X-Exception" , "quiet" );
+        }
+        catch ( JSException.Redirect r ){
+            response.sendRedirectTemporary(r.getTarget());
+        }
+        catch ( AppServerError ase ){
+            ar.getScope().clearToThrow();
+            handleError( request , response , ase , ar.getContext() );
+        }
+        catch ( Exception e ){
+            handleError( request , response , e , ar.getContext() );
+        }
+        finally {
+            _currentRequests.remove( ar );
+            if ( LEAK_HUNT )
+                LEAK_HUNT_SEMAPHORE.release();
+        }
+    }
+
+    void _handleEndOfServlet( HttpRequest request , HttpResponse response , AppRequest ar ){
+
+
+        String contentType = response.getHeader( "Content-Type" );
+        if ( contentType != null && contentType.indexOf( "text/html" ) < 0 )
+            return;
+
+        if (request.getHeader(_X10GEN_DEBUG) != null || request.get( _X10GEN_DEBUG ) != null ){
+            return;
+        }
+
+        // TODO: Eliot, be smarter about this
+        if ( response.getHeader( "Content-Length" ) != null )
+            return;
+
+        final JSObject user;
+        {
+            Object userMaybe = ar.getScope().get( "user" );
+            if ( userMaybe instanceof JSObject )
+                user = (JSObject)userMaybe;
+            else
+                user = null;
+        }
+
+        final JxpWriter out = response.getJxpWriter();
+
+        out.print( "\n<!-- " );
+        out.print( DNSUtil.getLocalHostString() );
+        out.print( "  " );
+        out.print( System.currentTimeMillis() - ar._created );
+        out.print( "ms " );
+        if ( ar._somethingCompiled )
+            out.print( " compile " );
+        out.print( " -->\n" );
+
+        if ( ar._profiler != null && showProfilingInfo( request , user ) ){
+            out.print( "<!--\n" );
+            out.print( ar._profiler.toString() );
+            out.print( "\n-->\n" );
+        }
+
+        if ( ar._appenderWriter != null ){
+            out.print( "<!--\n" );
+            ar._appenderWriter.flush();
+            out.print( ar._appenderStream.toString() );
+            out.print( "\n-->\n" );
+        }
+    }
+
+    boolean showProfilingInfo( HttpRequest request , JSObject user ){
+        if ( request.getBoolean( "profile" , false ) )
+            return true;
+
+        return user != null &&
+                (user.get("permissions") instanceof JSArray) &&
+                ((JSArray) (user.get("permissions"))).contains("admin");
+    }
+
+    /** Creates a 404 (page not found) response.
+     * @param ar the server's request object
+     * @param request the HTTP request for the non-existent page
+     * @param response the HTTP response to send back to the client
+     * @param extra any extra text to add to the response
+     */
+    void handle404( AppRequest ar , HttpRequest request , HttpResponse response , String extra ){
+        response.setResponseCode( 404 );
+
+        if ( ar.getFromInitScope( "handle404" ) instanceof JSFunction){
+            JSFunction func = (JSFunction)ar.getFromInitScope( "handle404" );
+            JxpServlet serv = new JxpServlet( ar.getContext() , func );
+            serv.handle( request , response , ar );
+            return;
+        }
+
+        response.getJxpWriter().print( "not found<br>" );
+
+        if ( extra != null )
+            response.getJxpWriter().print( extra + "<BR>" );
+
+        response.getJxpWriter().print( request.getRawHeader().replaceAll( "[\r\n]+" , "<br>" ) );
+
+    }
+
+    /** Kills this appserver if it runs out of memory.  Does a garbage collection
+     * and checks if enough memory was freed.  If not, or if the response writer fails,
+     * the appserver quits with a -3 exit code.
+     * @param oom The out-of-memory error
+     * @param response The HTTP response to inform the user of the error
+     */
+    void handleOutOfMemoryError( OutOfMemoryError oom , HttpResponse response ){
+        // 2 choices here, this request caused all sorts of problems
+        // or the server is screwed.
+
+        MemUtil.checkMemoryAndHalt( "AppServer" , oom , this );
+
+        if ( response.isCommitted() ){
+            // not much we can do with this
+            return;
+        }
+
+        // either this thread was the problem, or whatever
+
+        try {
+            response.setResponseCode( 500 );
+            JxpWriter writer = response.getJxpWriter();
+            writer.print( "There was an error handling your request (appsrv 123)<br>" );
+            writer.print( "ERR 71<br>" );
+        }
+        catch ( OutOfMemoryError oom2 ){
+            // forget it - we're super hosed
+            Runtime.getRuntime().halt( -3 );
+        }
+    }
+
+    /** Handles this appserver's errors.
+     * @param request The request that caused the error
+     * @param response The response to fill
+     * @param t The error thrown
+     * @param ctxt The app context to use for logging
+     */
+    void handleError( HttpRequest request , HttpResponse response , Throwable t , AppContext ctxt ){
+
+        final Logger myLogger = ctxt == null ? _noContextLogger : ctxt.getLogger();
+
+// {fact rule=log-injection@v1.0 defects=1}
+        if ( t.getCause() instanceof OutOfMemoryError ){
+            handleOutOfMemoryError( (OutOfMemoryError)t.getCause() , response );
+            return;
+        }
+
+// defect
+        myLogger.error( request.getFullURL() , t );
+
+        if ( response.isCommitted() ){
+            myLogger.error( "handleError called but response already commited.  request:" + request.getFullURL() );
+            return;
+        }
+// {/fact}
+
+        response.setResponseCode( 500 );
+
+        JxpWriter writer = response.getJxpWriter();
+
+        if ( t instanceof JSCompileException ){
+            JSCompileException jce = (JSCompileException)t;
+
+            writer.print( "<br><br><hr>" );
+            writer.print( "<h3>Compile Error</h3>" );
+            writer.print( "<b>Message:</b> " + jce.getError() + "<BR>" );
+            writer.print( "<b>File Name:</b> " + jce.getFileName() + "<BR>" );
+            writer.print( "<b>Line # :</b> " + jce.getLineNumber() + "<BR>" );
+
+            writer.print( "<!--\n" );
+            for ( StackTraceElement element : t.getStackTrace() ){
+                writer.print( element + "<BR>\n" );
+            }
+            writer.print( "-->" );
+        }
+        else {
+            writer.print( "\n<br><br><hr><b>Error</b><br>" );
+            writer.print("<pre>\n");
+
+
+            StackTraceElement[] parentTrace = new StackTraceElement[0];
+            while(t != null) {
+                //message
+                writer.print( Encoding._escapeHTML(t.toString()) + "\n");
+
+                //Compute # frames in common
+                StackTraceElement[] currentTrace = t.getStackTrace();
+
+                int m = currentTrace.length-1, n = parentTrace.length-1;
+                while (m >= 0 && n >=0 && currentTrace[m].equals(parentTrace[n])) {
+                    m--; n--;
+                }
+                int framesInCommon = currentTrace.length - 1 - m;
+
+                //print the frames
+                for(int i=0; i<= m; i++)
+                    writer.print("\tat " + Encoding._escapeHTML(currentTrace[i].toString()) +"\n");
+                if(framesInCommon != 0)
+                    writer.print("\t... " + framesInCommon + " more\n");
+
+                parentTrace = currentTrace;
+                t = t.getCause();
+
+                if(t != null)
+                    writer.print("Caused by: ");
+            }
+
+            writer.print("</pre>\n");
+        }
+    }
+
+    void handleNoSite( HttpRequest request , HttpResponse response ){
+        response.setResponseCode( 404 );
+        response.getJxpWriter().print( "No site for <b>" + request.getHost() + "</b>" );
+    }
+
+    /** Determines how long this response should be cached for.
+        result is to set Cache-Time and Expires
+     * @param ar The app request which contains the staticCacheTime function
+     * @param jsURI The URI to find in the cache
+     * @param request The HTTP request to process
+     * @param response The HTTP response to generate
+     * @return The time, in seconds
+     */
+    static int getCacheTime( AppRequest ar , File file , JSString jsURI , HttpRequest request , HttpResponse response ){
+
+        if ( ar.getFromInitScope( "staticCacheTime" ) != null ){
+            JSFunction f = (JSFunction)ar.getFromInitScope( "staticCacheTime" );
+            if ( f != null ){
+                Object ret = f.call( ar.getScope() , jsURI , request , response );
+                if ( ret instanceof Number )
+                    return ((Number)ret).intValue();
+            }
+        }
+        
+        if ( ! ar.isStatic() ||
+             request.getParameter( "lm" ) == null ||
+             request.getParameter( "ctxt" ) == null )
+            return -1;
+
+        if ( ! file.exists() )
+            return -1;
+        
+        if ( request.getParameter( "lm" ).equals( URLFixer.LM404 ) ){
+            // this is the really interesting one
+            // the cache url is wrong, but it does exist
+            return -1;
+        }
+
+        return DEFAULT_CACHE_S;
+    }
+
+    /** This appserver's priority for the HTTP request handler.
+     * @return 10000
+     */
+    public double priority(){
+        return 10000;
+    }
+
+    /** Resets the app content.
+     * @param ar Used to find the context to reset and logger
+     * @param request object representing client request
+     * @param response Set to inform the user what happens
+     */
+    void handleReset( AppRequest ar , HttpRequest request , HttpResponse response ){
+        response.setHeader( "Content-Type" , "text/plain" );
+
+        JxpWriter out = response.getJxpWriter();
+
+        out.print( "so, you want to reset?\n" );
+
+        if ( _administrativeAllowed( request ) ){
+            ar.getContext().getLogger().info("creating new context" );
+
+            ar.getContext().updateCode();
+            AppContext newContext = ar.getContext().newCopy();
+            newContext.getScope();
+            newContext.getFileSafe( "index.jxp" );
+            _contextHolder.replace( ar.getContext() , newContext );
+
+            ar.getContext().getLogger().info("done creating new context.  resetting" );
+            ar.getContext().reset();
+
+            out.print( "you did it!\n" );
+            out.print( "old hash:" + System.identityHashCode( ar.getContext() ) + "\n" );
+            out.print( "new hash:" + System.identityHashCode( newContext ) + "\n" );
+        }
+        else {
+            ar.getContext().getLogger().error("Failed attempted context reset via /~reset from " + request.getRemoteIP());
+            out.print( "you suck!" );
+            response.setResponseCode(403);
+        }
+
+    }
+
+    void handleUpdate( AppRequest ar , HttpRequest request , HttpResponse response ){
+        response.setHeader( "Content-Type" , "text/plain" );
+
+        JxpWriter out = response.getJxpWriter();
+
+        out.print( "you are going to update\n" );
+
+        if ( _administrativeAllowed( request ) ){
+            out.print( "you did it!\n" );
+            ar.getContext().getLogger().info("About to update context via /~update");
+            try {
+                String branch = ar.getContext().updateCode();
+                if ( branch == null )
+                    out.print( "couldn't update." );
+                else
+                    out.print( "updated to [" + branch + "]" );
+            }
+            catch ( Exception e ){
+                out.print( "Fail : " + e );
+            }
+            out.print( "\n" );
+        }
+        else {
+            ar.getContext().getLogger().error("Failed attempted context reset via /~update from " + request.getRemoteIP());
+            out.print( "you suck!" );
+            response.setResponseCode(403);
+        }
+    }
+
+    void handleAdmin( AppRequest ar , HttpRequest request , HttpResponse response ){
+
+        JxpWriter out = response.getJxpWriter();
+
+        if ( ! _administrativeAllowed( request ) ){
+            out.print( "you are not allowed here" );
+            return;
+        }
+
+        out.print( "<html><head>" );
+        out.print( "<title>admin | " + request.getHost() + "</title>" );
+        out.print( "</head><body>" );
+
+        out.print( "<h1>Quick Admin</h1>" );
+
+        out.print( "<table border='1'>" );
+        out.print( "<tr><th>Created</th><td>" + ar.getContext()._created + "</td></tr>" );
+        out.print( "<tr><th>Memory (kb)</th><td>" + ( ar.getContext().approxSize() / 1024 ) + "</td></tr>" );
+        out.print( "</table>" );
+
+        out.print( "<h3>Stats</h3>" );
+        getTracker( ar.getContext() ).displayGraph( out , _displayOptions );
+
+        out.print( "<hr>" );
+
+        out.print( "<a href='/~update'>Update Code</a> | " );
+        out.print( "<a href='/~reset'>Reset Site (include code update)</a> | " );
+
+        out.print( "</body></html>" );
+    }
+
+    boolean _administrativeAllowed( HttpRequest request ){
+        return
+            request.getPhysicalRemoteAddr().equals( "127.0.0.1" ) &&
+            request.getHeader( "X-Cluster-Cluster-Ip" ) == null;
+    }
+
+    HttpLoadTracker getTracker( final AppContext ctxt ){
+        final String site = ctxt._name;
+        final String env = ctxt._environment;
+        final String name = site + ":" + ( env == null ? "NONE" : env );
+
+        HttpLoadTracker t = _stats.get( name );
+        if ( t != null )
+            return t;
+
+        synchronized ( _stats ){
+            t = _stats.get( name );
+            if ( t == null ){
+                t = new HttpLoadTracker( name , 30 , 30 );
+                _stats.put( name , t );
+            }
+        }
+
+        return t;
+    }
+
+    public void printMemInfo(){
+        System.out.println( "AppServer.printMemInfo" );
+        for ( AppRequest ar : _currentRequests ){
+            System.err.print( "\t" );
+            System.err.print( ar._host );
+            System.err.print( "\t" );
+            System.err.print( ar._uri );
+            System.err.println();
+        }
+    }
+
+    public String toString(){
+        return "AppServer";
+    }
+
+    private final AppContextHolder _contextHolder;
+    private final Map<String,HttpLoadTracker> _stats = Collections.synchronizedMap( new StringMap<HttpLoadTracker>() );
+    private final WatchableRequestMonitor _requestMonitor = WatchableRequestMonitor.getInstance();
+    private final HttpLoadTracker.GraphOptions _displayOptions = new HttpLoadTracker.GraphOptions( 400 , 100 , true , true , true );
+    private final IdentitySet<AppRequest> _currentRequests = new IdentitySet<AppRequest>();
+
+    protected final static String _X10GEN_DEBUG = "X-10gen-Debug"; // private header - if set, user/profile/timing info won't be appended to response
+
+    static final Logger _noContextLogger = Logger.getLogger( "appserver.nocontext" );
+
+    // ---------
+
+    /** @unexpose */
+    public static void main( String args[] )
+        throws Exception {
+
+        String webRoot = null;
+        String sitesRoot = "/data/sites";
+
+        int portNum = DEFAULT_PORT;
+        boolean secure = false;
+
+        /*
+         *     --port portnum   [root]
+         */
+
+        int aLength = 0;
+        for ( int i=0; i<args.length; i++ ){
+            if ( args[i] != null && args[i].trim().length() > 0 )
+                aLength = i +1;
+        }
+        for (int i = 0; i < aLength; i++) {
+
+            if ("--port".equals(args[i])) {
+                portNum = Integer.valueOf(args[++i]);
+            }
+            else if ("--root".equals(args[i])) {
+                portNum = Integer.valueOf(args[++i]);
+            }
+            else if ("--serverroot".equals(args[i])) {
+                EDFinder.whereIsEd = args[++i];
+            }
+            else if ( "--sitesRoot".equals( args[i] ) ){
+                sitesRoot = args[++i];
+            }
+            else if ( "--secure" .equals( args[i] ) ){
+                secure = true;
+            }
+            else if ( "--insecure" .equals( args[i] ) ){
+                secure = false;
+            }
+            else {
+                if (i != aLength - 1) {
+                    System.out.println("error - unknown param " + args[i]);
+                    System.exit(1);
+                }
+                else {
+                    webRoot = args[i];
+                }
+            }
+        }
+
+        System.out.println("==================================");
+        System.out.println("  10gen AppServer vX");
+        System.out.println("     listen port = " + portNum);
+        System.out.println("     server root = " + EDFinder.whereIsEd);
+        System.out.println("         webRoot = " + webRoot);
+        System.out.println("       sitesRoot = " + sitesRoot);
+        System.out.println("     listen port = " + portNum);
+        System.out.println("          secure = " + secure);
+        if ( LEAK_HUNT )
+            System.out.println( "   LEAK HUNT ENABLED" );
+        System.out.println("==================================");
+
+        AppServer as = new AppServer( webRoot , sitesRoot );
+        if ( as._contextHolder._getDefaultContext() != null )
+            as._contextHolder._getDefaultContext().getScope();
+        as.addToServer();
+
+        HttpMonitor.setApplicationType( "Application Server" );
+        HttpServer hs = new HttpServer(portNum);
+        if ( secure )
+            System.setSecurityManager( new AppSecurityManager() );
+        hs.start();
+        hs.join();
+        if( !hs.hadCleanShutdown() )
+            System.exit( -1 );
+    }
+}

--- a/row_007_ClientServlet.java
+++ b/row_007_ClientServlet.java
@@ -1,0 +1,472 @@
+package com.mxgraph.online;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import net.sf.jsr107cache.Cache;
+import net.sf.jsr107cache.CacheException;
+import net.sf.jsr107cache.CacheManager;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Text;
+import com.google.apphosting.api.DeadlineExceededException;
+
+/**
+ * Servlet implementation class OpenServlet
+ * 
+ * TODOs
+ * -----
+ * 
+ * - Add validation of incoming version numbers. 
+ * 
+ */
+public class ClientServlet extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+	
+	/**
+	 * Connection constants
+	 */
+	private final static String JGRAPH_EVAL_REMOTE = "http://mxclient.jgraph.com/demo/mxgraph/src/js/mxclient.php?header=0&version=";
+	private final static int CONNECTION_TIMEOUT = 10 * 1000;
+	private final static int READ_TIMEOUT = 10 * 1000;
+	
+	private final static Logger LOGGER = Logger.getLogger(ClientServlet.class.getName());
+
+	
+	private final static StringBuilder MESSAGE_HEADER = new StringBuilder(
+			"// YOU ARE NOT PERMITED TO EXTRACT THE SOURCE OF THIS APPLICATION FOR EXECUTION LOCALLY.\n// YOUR IP ADDRESS HAS BEEN LOGGED, ABUSES WILL CAUSE ACCESS TO THE JGRAPH SERVER TO BE BLOCKED.\n");
+	// IE date format for If-Modified-Since and Last-Modified
+	private final static SimpleDateFormat IE = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z");
+	private final static SimpleDateFormat MESSAGE_HEADER_DATE_FORMAT = new SimpleDateFormat("d MMM yyyy HH:mm:ss");
+	private final static String ALERT_RESPONSE_REGEX = ".*alert\\(\\\".*\"\\);.*";
+	
+	private final static int SCRIPT_BUFFER_SIZE = 1048576;
+
+	/**
+	 * Data Store Entity constants
+	 * */
+	private final static String ENTITY_KEY_KIND = "mxGraphScript";
+	private final static String ENTITY_SCRIPT = "script";
+	private final static String ENTITY_DATE_MODIFIED = "dateModified";
+	
+	private final static String CACHE_KEY = "5ecba5bd1d4a23e36cddf80c151df716";
+
+	/**
+	 * @see HttpServlet#HttpServlet()
+	 */
+	public ClientServlet() {
+		super();
+	}
+
+	/**
+	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+	 */
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+		String stringMessage = null;
+		String version = request.getParameter("version");
+		Object[] dateScriptPair = null;
+
+		String internalAgentCode = getInternalUserAgent(request);
+
+		if (internalAgentCode == null) {
+			// Need to send us a sensible user agent
+			LOGGER.warning("Invalid user agent.");
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		String cacheCode = "mx-" + internalAgentCode + "-" + version;
+		
+		if(isClearCache(request)) {
+			try {
+				clearCache();
+				clearDataStore(cacheCode);
+				LOGGER.info("Cache cleared.");
+			} catch (Exception e) {
+				LOGGER.severe("Error clearing cache : " + e.toString());
+			}
+		}
+			
+		if (version == null) {
+			// Need to send us a version
+			LOGGER.warning("No version requested.");
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		try {
+			dateScriptPair = getData(cacheCode);
+		} catch (DeadlineExceededException e) {
+			LOGGER.severe("Request is taking too long to complete. Remote IP : " + request.getRemoteAddr() + ", internal agent code : " + internalAgentCode + ", script version : " + version + ". Original exception : " + e.getMessage());
+		}
+
+
+		try {
+			// if it's not found in server cache, get the script from the server, stamp it and cache it
+			if (dateScriptPair == null) {
+				LOGGER.info("Script not found in cache.");
+				// Create a URL for the desired page
+// {fact rule=log-injection@v1.0 defects=1}
+				URL url = new URL(JGRAPH_EVAL_REMOTE + version);
+
+				stringMessage = getScript(url, request);
+				
+				if(checkResponseStringForAlert(stringMessage)) {
+// defect
+					LOGGER.info("Response contained a JavaScript alert : " + stringMessage);
+					sendResponse(response, stringMessage);
+					return;
+				}
+
+				if (!checkScript(stringMessage)) {
+// {/fact}
+					LOGGER.severe("CRC check failed!");
+				}
+
+				Date dateModified = new Date();
+				dateScriptPair = new Object[2];
+				dateScriptPair[0] = dateModified.getTime() / 1000 * 1000;// have to round the date to conform to IE....
+				dateScriptPair[1] = stringMessage;
+				response.addHeader("Last-Modified", dateScriptPair[0].toString());
+				
+				storeData(cacheCode, dateScriptPair);
+
+			} else { // found it in cache, check the stamp in browser's cache and send "304 Not Modified" if it's cached on the client side
+				LOGGER.info("Script found in cache.");
+
+				response.addHeader("Last-Modified", dateScriptPair[0].toString());
+
+				if (isSend304(request, response, dateScriptPair)) {
+					LOGGER.info("304 Not Modified");
+					response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+					return;
+				}
+
+			}
+		} catch (Throwable e) {
+			LOGGER.warning(e.toString());
+		}
+
+		LOGGER.info("Sending script.");
+		sendResponse(response, formatMessage(request, (Long) dateScriptPair[0], (String) dateScriptPair[1]));
+
+	}
+	
+	private boolean isClearCache(HttpServletRequest request) {
+		String cc = request.getParameter("clearcache");
+		return cc != null && cc.equals(CACHE_KEY);
+	}
+	
+	private void clearCache() {
+		Cache cache = null;
+		try {
+			cache = CacheManager.getInstance().getCacheFactory().createCache(Collections.emptyMap());
+		} catch (CacheException e) {
+			LOGGER.warning(e.toString());
+		}
+		
+		if(cache != null) {
+			cache.clear();
+		}
+	}
+	
+	private void clearDataStore(String key) {
+		DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+		Query q = new Query(ENTITY_KEY_KIND);
+		PreparedQuery pq = datastore.prepare(q);
+		
+		ArrayList<Key> keys = new ArrayList<Key>();
+		
+		for(Entity e : pq.asIterable()) {
+			keys.add(e.getKey());
+		}
+		
+		datastore.delete(keys);
+	}
+
+	private Object[] getData(String key) {
+
+		Object[] data = null;
+
+		data = getDataFromCache(key);
+
+		if (data == null) {
+			data = getDataFromDataStore(key);
+			
+			//found in data store but not in memcache so cache it
+			if(data != null) {
+				storeDataInCache(key, data);
+			}
+		}//found in memcache but not in data store so store it
+		else if(getDataFromDataStore(key) == null) {
+			storeDataInDataStore(key, data);
+		}
+
+		return data;
+	}
+
+	private Object[] getDataFromCache(String key) {
+		Object[] data = null;
+		Cache cache = null;
+		try {
+			cache = CacheManager.getInstance().getCacheFactory().createCache(Collections.emptyMap());
+		} catch (CacheException e) {
+			LOGGER.warning(e.toString());
+		}
+
+		if (cache != null) {
+			data = (Object[]) cache.get(key);
+		}
+
+		return data;
+	}
+	
+	private void storeDataInCache(String key, Object [] data) {
+		
+		Cache cache = null;
+		try {
+			cache = CacheManager.getInstance().getCacheFactory().createCache(Collections.emptyMap());
+		} catch (CacheException e) {
+			LOGGER.warning(e.toString());
+		}
+		
+		if (cache != null) {
+			cache.put(key, data);
+		}
+		
+	}
+	
+	private void storeData(String key, Object [] data) {
+		storeDataInCache(key, data);
+		storeDataInDataStore(key, data);
+	}
+	
+	private void storeDataInDataStore(String key, Object [] data) {
+		DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+		
+		Entity entity = new Entity(ENTITY_KEY_KIND, key);
+		entity.setProperty(ENTITY_DATE_MODIFIED, data[0]);
+		entity.setProperty(ENTITY_SCRIPT, new Text((String)data[1]));
+		
+		datastore.put(entity);
+	}
+
+	private Object[] getDataFromDataStore(String key) {
+		Object[] data = null;
+		DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+		if (data == null) {
+			Key cacheKey = KeyFactory.createKey(ENTITY_KEY_KIND, key);
+			try {
+				Entity entity = datastore.get(cacheKey);
+				Text text = (Text) entity.getProperty(ENTITY_SCRIPT);
+				Long dateModified = (Long) entity.getProperty(ENTITY_DATE_MODIFIED);
+				data = new Object[2];
+				data[0] = dateModified.longValue();
+				data[1] = text.getValue();
+
+			} catch (EntityNotFoundException e) {
+				
+			}
+
+		}
+
+		return data;
+	}
+
+	private String formatMessage(HttpServletRequest request, Long creationDate, String script) {
+		StringBuilder sb = new StringBuilder(MESSAGE_HEADER);
+		sb.append("// File created " + MESSAGE_HEADER_DATE_FORMAT.format(creationDate) + " for " + request.getHeader("user-agent") + " IP "
+				+ request.getRemoteAddr() + "\n");
+		sb.append(script);
+		return sb.toString();
+
+	}
+
+	private boolean isSend304(HttpServletRequest request, HttpServletResponse response, Object[] dateScriptPair) {
+		String ifMod = request.getHeader("If-Modified-Since");
+		// if the stamps on the server and client match, no need to send the whole script again, just use the one in browser cache
+		if (ifMod != null && !ifMod.equals("")) {
+			Long ifModified = parseIfModified(ifMod);
+
+			Long lastModified = (Long) dateScriptPair[0];
+			return ifModified >= lastModified;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Zips and sends the script
+	 * 
+	 * @param response
+	 * @param data
+	 */
+	private void sendResponse(HttpServletResponse response, String data) {
+		response.setContentType("application/x-javascript");
+		response.addHeader("Cache-Control", "private");
+		response.setStatus(HttpServletResponse.SC_OK);
+		OutputStream out = null;
+
+		try {
+			out = response.getOutputStream();
+			out.write(data.getBytes());
+		} catch (Throwable e) {
+			LOGGER.warning(e.toString());
+		} finally {
+			try {
+				if (out != null) {
+					out.close();
+				}
+			} catch (IOException e) {
+			}
+		}
+	}
+
+	private boolean checkScript(String string) throws IOException {
+
+		if (string == null) {
+			return false;
+		}
+
+		BufferedReader reader = new BufferedReader(new StringReader(string));
+		String crcLine = reader.readLine();
+		reader.readLine();
+		String script = reader.readLine();
+		return checkCrc(Long.parseLong(crcLine.split("=")[1]), script);
+	}
+
+	private boolean checkCrc(Long remoteCrc, String javascript) {
+		CRC32 crc = new CRC32();
+		crc.update(javascript.getBytes());
+
+		return remoteCrc == crc.getValue();
+	}
+
+	/**
+	 * Reads the script from the specified URL
+	 * 
+	 * @param url URL to read the script from
+	 * @param request request specifying the user agent
+	 * @return
+	 */
+	private String getScript(URL url, HttpServletRequest request) {
+		StringBuilder mxclient = new StringBuilder();
+		BufferedInputStream in = null;
+
+		try {
+			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+			conn.setConnectTimeout(CONNECTION_TIMEOUT);
+			conn.setReadTimeout(READ_TIMEOUT);
+			conn.setRequestMethod("GET");
+			conn.setRequestProperty("User-Agent", request.getHeader("user-agent"));
+			conn.connect();
+
+			byte[] byteBuffer = new byte[SCRIPT_BUFFER_SIZE];
+			in = new BufferedInputStream(conn.getInputStream());
+
+			in.read(byteBuffer);
+			mxclient.append(new String(byteBuffer, Charset.forName("UTF-8")).trim());
+		} catch (Throwable e) {
+			LOGGER.severe(e.toString());
+		} finally {
+			if (in != null) {
+				try {
+					in.close();
+				} catch (IOException e) {
+				}
+			}
+		}
+
+		return mxclient.toString();
+	}
+
+	/**
+	 * Parses the If-Modified String which can either be long or date(IE).
+	 * 
+	 * @param ifModStr input string
+	 * @return long
+	 */
+	private Long parseIfModified(String ifModStr) {
+
+		try {
+			Long ifModLong = Long.parseLong(ifModStr);
+			return ifModLong;
+		} catch (Exception e) {
+		}
+
+		try {
+			Date ifModDate = IE.parse(ifModStr);
+			return ifModDate.getTime();
+		} catch (ParseException e) {
+			LOGGER.warning(e.toString());
+		}
+
+		return null;
+	}
+
+	private String getInternalUserAgent(HttpServletRequest request) {
+
+		String userAgent = request.getHeader("user-agent").toUpperCase();
+
+		boolean isIe = userAgent.contains("MSIE");
+		boolean isIe6 = userAgent.contains("MSIE 6");
+		boolean isNs = userAgent.contains("MOZILLA/") && !isIe;
+		boolean isOp = userAgent.contains("OPERA/");
+		boolean isGc = userAgent.contains("CHROME/");
+		boolean isSf = userAgent.contains("APPLEWEBKIT/") && !isGc;
+		boolean isMt = (userAgent.contains("FIREFOX/") && !userAgent.contains("FIREFOX/1") && !userAgent.contains("FIREFOX/2"))
+				|| (userAgent.contains("ICEWEASEL/")) && !(userAgent.contains("ICEWEASEL/1")) && !(userAgent.contains("ICEWEASEL/2"))
+				|| (userAgent.contains("SEAMONKEY/")) && !(userAgent.contains("SEAMONKEY/1"))
+				|| (userAgent.contains("ICEAPE/") && !(userAgent.contains("ICEAPE/1")));
+
+		if (isIe6) {
+			return "ie6";
+		} else if (isIe) {
+			return "ie";
+		} else if (isGc) {
+			return "gc";
+		} else if (isSf) {
+			return "sf";
+		} else if (isOp) {
+			return "op";
+		} else if (isMt) {
+			return "mt";
+		} else if (isNs) {
+			return "ns";
+		}
+
+		return null;
+	}
+	
+	private boolean checkResponseStringForAlert(String responseString) {
+		return  Pattern.matches(ALERT_RESPONSE_REGEX, responseString);
+	}
+}

--- a/row_019_SessionFilter.java
+++ b/row_019_SessionFilter.java
@@ -1,0 +1,140 @@
+package com.client;
+
+import com.client.core.security.tools.RC4;
+import com.google.common.collect.ImmutableSet;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Filter used to authentication all calls to the web application.
+ *
+ * Current implementation is only to allow calls that either
+ * <ol>
+ *     <li>Have an 'apiKey' parameter on them equal to the apiKey in the application settings file (i.e. the one injected into {@link ApplicationSettings}</li>
+ *     <li>Have an encrypted 'apiKey' in the session.  This essentially means that some previous request had an 'apiKey' url parameter and passed the filter.</li>
+ * </ol>
+ */
+@Log4j2
+@Component
+public class SessionFilter extends OncePerRequestFilter {
+	private final String sessionStoredApiKeyName;
+	private final String encryptionKey;
+    private final String apiKey;
+	private static final Set<String> EXCLUDED_URL_PATHS = ImmutableSet.of("/crossdomain.xml");
+
+	public SessionFilter(ApplicationSettings appSettings) {
+		super();
+		this.sessionStoredApiKeyName = RandomStringUtils.randomAlphanumeric(32);
+		this.encryptionKey = RandomStringUtils.randomAlphanumeric(16);
+        this.apiKey = appSettings.apiKey();
+	}
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+		if (EXCLUDED_URL_PATHS.contains(request.getServletPath())) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		final HttpSession session = getSession(request);
+		final String apiKey = getApiKeyFromRequest(request);
+		final String previouslyAuthorizedApiKeyEncrypted = getApiKeyFromSession(session);
+		final String url = request.getRequestURL().toString();
+
+		boolean allowIn = false;
+
+		if (validApiKeyInSession(previouslyAuthorizedApiKeyEncrypted)) {
+			allowIn = true;
+		}
+
+		if (validApiKey(apiKey)) {
+			allowIn = true;
+// {fact rule=log-injection@v1.0 defects=1}
+
+			encryptApiKeyAndAddToSession(session, apiKey);
+		}
+
+		if (!allowIn) {
+// defect
+			log.info("Attempt to get to page: " + url + " was blocked in the SessionFilter. Returning 401 unauthorized response.");
+
+			response.sendError(HttpStatus.UNAUTHORIZED.value());
+		} else {
+            filterChain.doFilter(request, response);
+		}
+// {/fact}
+	}
+
+	private void encryptApiKeyAndAddToSession(HttpSession session, String apiKey) {
+		String encryptedApiKey = encryptApiKey(apiKey);
+
+		session.setAttribute(sessionStoredApiKeyName, encryptedApiKey);
+	}
+
+	public String encryptApiKey(String apiKey) {
+		return RC4.encryptAndEncode(apiKey, encryptionKey);
+	}
+
+	private boolean validApiKeyInSession(String previouslyAuthorizedApiKeyEncrypted) {
+		if (StringUtils.isBlank(previouslyAuthorizedApiKeyEncrypted)) {
+			return false;
+		}
+
+		String decryptedApiKey = decryptApiKey(previouslyAuthorizedApiKeyEncrypted);
+
+		return validApiKey(decryptedApiKey);
+	}
+
+    private String decryptApiKey(String previouslyAuthorizedApiKeyEncrypted) {
+        return RC4.decodeAndDecrypt(previouslyAuthorizedApiKeyEncrypted, encryptionKey);
+    }
+
+	private HttpSession getSession(HttpServletRequest request) {
+		return request.getSession();
+	}
+
+    private String getApiKeyFromSession(HttpSession session) {
+        return (String) session.getAttribute(sessionStoredApiKeyName);
+    }
+
+	private String getApiKeyFromRequest(HttpServletRequest request) {
+		String apiKey = request.getParameter("apiKey");
+
+		if (apiKey == null) {
+			apiKey = "";
+		}
+
+		String[] tmp = apiKey.split("\\?");
+
+		if (tmp.length > 1) {
+			apiKey = tmp[0];
+		}
+
+		return apiKey;
+	}
+
+	private boolean validApiKey(String apiKey) {
+		if (apiKey == null) {
+			apiKey = "";
+		}
+
+		return apiKey.equals(this.apiKey);
+	}
+
+    public String getSessionStoredApiKeyName() {
+        return sessionStoredApiKeyName;
+    }
+
+}


### PR DESCRIPTION
## 📝 Description
This PR adds a batch of Java files from the `java_log-injection-annotated` directory to the repository.

## 📁 Files Added
- Source Folder: `java_log-injection-annotated`
- Batch: java-log-injection-annotated-java-batch-02
- Language: Java
- Contains java files collected from the source directory

## 🔍 Changes
- Added java files from `java_log-injection-annotated` maintaining original directory structure
- Files organized in batch 02 for easier review
- Ready for integration and testing

## 💾 Source
Original files sourced from: `java_log-injection-annotated`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new Java server components: Office-to-PDF servlet, full HTTP AppServer, client script proxy with caching, and a session filter enforcing API key auth.
> 
> - **Backend/Server**:
>   - **Office conversion servlet** (`XOfficeServlet.java`): Converts uploaded or remote `doc/xls/ppt` to PDF, optional watermarking, temp-file caching, and HTTP fetching with redirects.
>   - **HTTP AppServer** (`AppServer.java`): Handles requests, static file serving with cache control, servlet execution, error handling, profiling hooks, and admin endpoints (`/~reset`, `/~update`, `/~admin`).
>   - **Client script proxy/cache** (`ClientServlet.java`): Proxies mxGraph client script by version, validates via CRC, adds headers, and caches via GAE Memcache/Datastore with 304 handling and cache-clear support.
>   - **Session filter** (`SessionFilter.java`): Enforces API key via request param or encrypted session value; excludes specific paths and returns 401 on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0c85ee141a4252e8f313afd54b0e0878c788a4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->